### PR TITLE
Adding prototype for profile pages.

### DIFF
--- a/src/main/java/codeu/controller/ProfileServlet.java
+++ b/src/main/java/codeu/controller/ProfileServlet.java
@@ -1,0 +1,16 @@
+package codeu.controller;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ProfileServlet extends HttpServlet{
+	
+	@Override
+	  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+		request.getRequestDispatcher("/WEB-INF/view/profile.jsp").forward(request, response);
+	  }
+}

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -71,7 +71,7 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
         String author = UserStore.getInstance()
           .getUser(message.getAuthorId()).getName();
     %>
-      <li><strong><%= author %>:</strong> <%= message.getContent() %></li>
+      <li><strong><a href="/user/<%= author %>"><%= author %></strong></a>:<%= message.getContent() %></li>
     <%
       }
     %>

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -1,0 +1,68 @@
+<%--
+  Copyright 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Profile</title>
+  <link rel="stylesheet" href="/css/main.css">
+  <style>
+    #messages {
+      background-color: white;
+      height: 500px;
+      overflow-y: scroll
+    }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a id="navTitle" href="/">CodeU Chat App</a>
+    <a href="/conversations">Conversations</a>
+    <% if(request.getSession().getAttribute("user") != null){ %>
+      <a>Hello <%= request.getSession().getAttribute("user") %>!</a>
+    <% } else{ %>
+      <a href="/login">Login</a>
+    <% } %>
+    <a href="/about.jsp">About</a>
+  </nav>
+
+  <div id="container">
+    <% String url = request.getAttribute("javax.servlet.forward.request_uri").toString();
+       String user = url.substring(url.lastIndexOf('/') + 1); %>
+    <h1><%= user + "'s" %> Profile Page</h1>
+    <hr/>
+
+    <h2>About <%= user %></h2>
+    <p>Temporary About Me</p>
+  
+    <form action="/profile" method="POST">
+        <label for="username">Edit Your About Me: </label>
+        <br/>
+        <textarea rows="8" cols="50" type="text" name="AboutMe" id="AboutMe"></textarea>
+        <br/>
+        <button type="submit">Submit</button>
+    </form>
+    <hr/>
+
+    <h3><%= user + "'s"%> Sent Messages</h3>
+    <div id="messages">
+      <ul>
+       <li>Demo Message</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -66,4 +66,14 @@
     <url-pattern>/register</url-pattern>
   </servlet-mapping>
 
+  <servlet>
+    <servlet-name>ProfileServlet</servlet-name>
+    <servlet-class>codeu.controller.ProfileServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>ProfileServlet</servlet-name>
+    <url-pattern>/user/*</url-pattern>
+  </servlet-mapping>
+
 </web-app>

--- a/src/test/java/codeu/controller/ProfileServletTest.java
+++ b/src/test/java/codeu/controller/ProfileServletTest.java
@@ -1,0 +1,36 @@
+package codeu.controller;
+
+import java.io.IOException;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ProfileServletTest {
+	
+	  private ProfileServlet ProfileServlet;
+	  private HttpServletRequest mockRequest;
+	  private HttpServletResponse mockResponse;
+	  private RequestDispatcher mockRequestDispatcher;
+
+	  @Before
+	  public void setup() throws IOException {
+	    ProfileServlet = new ProfileServlet();
+	    mockRequest = Mockito.mock(HttpServletRequest.class);
+	    mockResponse = Mockito.mock(HttpServletResponse.class);
+	    mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
+	    Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/profile.jsp"))
+	        .thenReturn(mockRequestDispatcher);
+	  }
+	  
+	  @Test
+	  public void testDoGet() throws IOException, ServletException {
+	    ProfileServlet.doGet(mockRequest, mockResponse);
+	    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+	  }
+}


### PR DESCRIPTION
To view a user profile type in the http://localhost:8080/user/* (* meaning any username), messages in a conversation should also now have the usernames hyperlinked and clicking on the usernames should take you to the user’s profile page. 
Does not take in user input.

Prototype Changes
New Files:
Classes: ProfileServlet.java, ProfileServletTest.java
doGet loads the profile.jsp
JSP: Profile.jsp
The temporary user’s profile page
Modified Files:
XML: web.xml
Added the link for ProfileServerlet to /users/* uri’s
JSP: Chat.jsp  
Now links user names from messages to their profile page
