### PR TITLE
Fixing the String return to be more concise

### DIFF
--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -105,6 +105,6 @@ public class ConversationStore {
    * Method to return the number of conversations
    */
   public String count() {
-	  return "" + conversations.size();
+	  return String.valueOf(conversations.size());
   }
 }

--- a/src/main/java/codeu/model/store/basic/MessageStore.java
+++ b/src/main/java/codeu/model/store/basic/MessageStore.java
@@ -102,6 +102,6 @@ public class MessageStore {
    * Method that returns the number of messages
    */
   public String count() {
-	  return "" + messages.size();
+	  return String.valueOf(messages.size());
   }
 }

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -139,7 +139,7 @@ public class UserStore {
    * Method to return the number of users
    */
   public String count() {
-	  return "" + users.size();
+	  return String.valueOf(users.size());
   }
 }
 


### PR DESCRIPTION
This is a simple change that changes the return value from String concatenation to using the String class's valueOf() method.

The classes that are changed by this pull request are:
- ConversationStore.java
- MessageStore.java
- UserStore.java