### PR TITLE
Ad toggle prototype

### DIFF
--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -96,6 +96,7 @@
       <h3>You seem to not have friends (yet!)</h3>
     <% } %>
     </div>
+    <hr/>
 
     <h3><%= user.getName() + "'s"%> Sent Messages</h3>
     <div id="messages">
@@ -106,7 +107,16 @@
     <% } else { %>
       <p>User Does Not Exist</p>
     <% } %>
+
+    <h3>Ad Toggle</h3>
+    <div id="ad slider">
+    <label class="switch">
+      <input type="checkbox">
+      <span class="slider round"></span>
+    </label>
+    </div>
   </div>
+
   <footer>
     <nav>
       <a href="/adminPage">Administration</a>

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -58,9 +58,8 @@ button {
 }
 
 footer {
-  position: fixed;
-  left: 0;
-  bottom: 0;
+  position:relative;
   width: 100%;
-  text-align: left;
+  text-align:left;
+  padding:15px 0;
 }


### PR DESCRIPTION
This pull request adds in a simple switch to the bottom of the profile page that will be how users decide if they want ads or not. The switch has not been connected to any code yet, it is simply there.

<img width="179" alt="ads" src="https://user-images.githubusercontent.com/33306040/41568770-4d73378c-732d-11e8-906c-861c07ca6fba.png"> 

Also, I though I did this in a different branch, but I changed how the footer behaves. It now stays at the bottom of the page's content. This means it no longer overlaps with certain pieces of the site, but isn't guaranteed to be at the bottom of the browser window.
