### PR TITLE
Roses branch

### DIFF
--- a/src/main/java/codeu/controller/AllConversationsServlet.java
+++ b/src/main/java/codeu/controller/AllConversationsServlet.java
@@ -29,6 +29,7 @@ public class AllConversationsServlet extends HttpServlet{
 		    this.conversationStore = conversationStore;
 		  }
 	   
+	   
 	   @Override
 	   public void doGet(HttpServletRequest request, HttpServletResponse response)
 	      throws IOException, ServletException {

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -124,6 +124,18 @@ public class ChatServlet extends HttpServlet {
     request.setAttribute("messages", messages);
     request.getRequestDispatcher("/WEB-INF/view/chat.jsp").forward(request, response);
   }
+  
+  public String mentionedUser(String possibleMention) {
+	  String name = "";
+	  if(possibleMention.charAt(0) == '@') {
+		name = possibleMention.split("\\s+")[0];
+		name = name.substring(1);
+		if(userStore.getUser(name) != null) {
+			return name;
+		}
+	  }
+	return name;
+  }
 
   /**
    * This function fires when a user submits the form on the chat page. It gets the logged-in
@@ -160,9 +172,7 @@ public class ChatServlet extends HttpServlet {
     }
 
     TextProcessor processor = BBProcessorFactory.getInstance().create();
-    
     String messageContent = request.getParameter("message");
-    
     // this removes any HTML from the message content
     String cleanedMessageContent = processor.process(Jsoup.clean(messageContent, Whitelist.none()));
     
@@ -178,7 +188,10 @@ public class ChatServlet extends HttpServlet {
             //displays the edited message
             emojis,
             Instant.now());
-
+    if(mentionedUser(emojis) != "") {
+    	System.out.println(mentionedUser(emojis));
+    }
+    
     messageStore.addMessage(message);
     
     DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -124,18 +124,6 @@ public class ChatServlet extends HttpServlet {
     request.setAttribute("messages", messages);
     request.getRequestDispatcher("/WEB-INF/view/chat.jsp").forward(request, response);
   }
-  
-  public String mentionedUser(String possibleMention) {
-	  String name = "";
-	  if(possibleMention.charAt(0) == '@') {
-		name = possibleMention.split("\\s+")[0];
-		name = name.substring(1);
-		if(userStore.getUser(name) != null) {
-			return name;
-		}
-	  }
-	return name;
-  }
 
   /**
    * This function fires when a user submits the form on the chat page. It gets the logged-in
@@ -174,7 +162,7 @@ public class ChatServlet extends HttpServlet {
     TextProcessor processor = BBProcessorFactory.getInstance().create();
     
     String messageContent = request.getParameter("message");
-    String mention = mentionedUser(messageContent);
+    
     // this removes any HTML from the message content
     String cleanedMessageContent = processor.process(Jsoup.clean(messageContent, Whitelist.none()));
     
@@ -190,7 +178,7 @@ public class ChatServlet extends HttpServlet {
             //displays the edited message
             emojis,
             Instant.now());
-    System.out.println(mention);
+
     messageStore.addMessage(message);
     
     DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -124,6 +124,18 @@ public class ChatServlet extends HttpServlet {
     request.setAttribute("messages", messages);
     request.getRequestDispatcher("/WEB-INF/view/chat.jsp").forward(request, response);
   }
+  
+  public String mentionedUser(String possibleMention) {
+	  String name = "";
+	  if(possibleMention.charAt(0) == '@') {
+		name = possibleMention.split("\\s+")[0];
+		name = name.substring(1);
+		if(userStore.getUser(name) != null) {
+			return name;
+		}
+	  }
+	return name;
+  }
 
   /**
    * This function fires when a user submits the form on the chat page. It gets the logged-in
@@ -162,7 +174,7 @@ public class ChatServlet extends HttpServlet {
     TextProcessor processor = BBProcessorFactory.getInstance().create();
     
     String messageContent = request.getParameter("message");
-    
+    String mention = mentionedUser(messageContent);
     // this removes any HTML from the message content
     String cleanedMessageContent = processor.process(Jsoup.clean(messageContent, Whitelist.none()));
     
@@ -178,7 +190,7 @@ public class ChatServlet extends HttpServlet {
             //displays the edited message
             emojis,
             Instant.now());
-
+    System.out.println(mention);
     messageStore.addMessage(message);
     
     DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -36,7 +36,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 import org.kefirsf.bb.BBProcessorFactory;
 import org.kefirsf.bb.TextProcessor;
-
 import com.vdurmont.emoji.EmojiParser;
 
 /** Servlet class responsible for the chat page. */
@@ -96,6 +95,7 @@ public class ChatServlet extends HttpServlet {
   void setUserStore(UserStore userStore) {
     this.userStore = userStore;
   }
+ 
 
   /**
    * This function fires when a user navigates to the chat page. It gets the conversation title from
@@ -117,7 +117,6 @@ public class ChatServlet extends HttpServlet {
     }
 
     UUID conversationId = conversation.getId();
-
     List<Message> messages = messageStore.getMessagesInConversation(conversationId);
 
     request.setAttribute("conversation", conversation);
@@ -125,7 +124,7 @@ public class ChatServlet extends HttpServlet {
     request.getRequestDispatcher("/WEB-INF/view/chat.jsp").forward(request, response);
   }
   
-  public String mentionedUser(String possibleMention) {
+  /*public String mentionedUser(String possibleMention) {
 	  String name = "";
 	  if(possibleMention.charAt(0) == '@') {
 		name = possibleMention.split("\\s+")[0];
@@ -136,6 +135,7 @@ public class ChatServlet extends HttpServlet {
 	  }
 	return name;
   }
+  */
 
   /**
    * This function fires when a user submits the form on the chat page. It gets the logged-in
@@ -170,7 +170,19 @@ public class ChatServlet extends HttpServlet {
       response.sendRedirect("/conversations");
       return;
     }
-
+    
+    response.setContentType("/chat/");
+    String publicConvo = request.getParameter("privacy");
+    System.out.println(publicConvo);
+    if(publicConvo != null) {
+    	if(publicConvo.equals("private")) {
+    		conversation.setPublicStatus(false);
+    	}else {
+    		conversation.setPublicStatus(true);
+    	}
+    }
+    
+    
     TextProcessor processor = BBProcessorFactory.getInstance().create();
     String messageContent = request.getParameter("message");
     // this removes any HTML from the message content
@@ -188,9 +200,9 @@ public class ChatServlet extends HttpServlet {
             //displays the edited message
             emojis,
             Instant.now());
-    if(mentionedUser(emojis) != "") {
-    	System.out.println(mentionedUser(emojis));
-    }
+    //if(mentionedUser(emojis) != "") {
+    //	System.out.println(mentionedUser(emojis));
+    //}
     
     messageStore.addMessage(message);
     

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -128,9 +128,11 @@ public class ConversationServlet extends HttpServlet {
       response.sendRedirect("/chat/" + conversationTitle);
       return;
     }
+    
+    
 
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now());
+        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now(), true);
     
     DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;
     String activityContent = conversation.getCreationTime().atOffset(ZoneOffset.of("Z")).format(formatter) + ": " + username + " created a new conversation: " + conversation.getTitle();

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -26,6 +26,7 @@ public class Conversation {
   public final UUID owner;
   public final Instant creation;
   public final String title;
+  public boolean openConvo;
 
   /**
    * Constructs a new Conversation.
@@ -35,12 +36,14 @@ public class Conversation {
    * @param title the title of this Conversation
    * @param creation the creation time of this Conversation
    */
-  public Conversation(UUID id, UUID owner, String title, Instant creation) {
+  public Conversation(UUID id, UUID owner, String title, Instant creation, boolean open) {
     this.id = id;
     this.owner = owner;
     this.creation = creation;
     this.title = title;
+    this.openConvo = true;
   }
+  
 
   /** Returns the ID of this Conversation. */
   public UUID getId() {
@@ -60,5 +63,14 @@ public class Conversation {
   /** Returns the creation time of this Conversation. */
   public Instant getCreationTime() {
     return creation;
+  }
+  
+  /**returns if the conversation is public or private*/
+  public boolean getPublicStatus() {
+	  return openConvo;
+  }
+  
+  public void setPublicStatus(boolean status) {
+	  this.openConvo = status;
   }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -138,7 +138,7 @@ public class PersistentDataStore {
         UUID ownerUuid = UUID.fromString((String) entity.getProperty("owner_uuid"));
         String title = (String) entity.getProperty("title");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
-        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime);
+        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime, true);
         conversations.add(conversation);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may

--- a/src/main/webapp/WEB-INF/view/allConversations.jsp
+++ b/src/main/webapp/WEB-INF/view/allConversations.jsp
@@ -17,9 +17,6 @@
 <%@ page import="java.util.List" %>
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.store.basic.ConversationStore" %>
-<%
-List<Conversation> conversations = (List<Conversation>) request.getAttribute("conversations");
-%>
 
 <!DOCTYPE html>
 <html>
@@ -45,19 +42,32 @@ List<Conversation> conversations = (List<Conversation>) request.getAttribute("co
   <H1>All Public Conversations</h1>
   <input type="text" placeholder="Search..">
   <div>
-  <ul>
-    <% if(conversations == null){ %>
-    <li>No public conversations</li>
-    <% } else { 
-      for (Conversation conversation : conversations) {
-        String content = conversation.getTitle();
+    <h1>Conversations</h1>
+
+    <%
+    List<Conversation> conversations =
+      (List<Conversation>) request.getAttribute("conversations");
+    if(conversations == null || conversations.isEmpty()){
     %>
-      <li><%= content %></li>
+      <p>Create a conversation to get started.</p>
+    <%
+    }
+    else{
+    %>
+      <ul class="mdl-list">
+    <%
+      for(Conversation conversation : conversations){
+    %>
+      <li><a href="/chat/<%= conversation.getTitle() %>">
+        <%= conversation.getTitle() %></a></li>
     <%
       }
-    }
     %>
       </ul>
+    <%
+    }
+    %>
+    <hr/>
   </div>
 
 </body>

--- a/src/main/webapp/WEB-INF/view/allConversations.jsp
+++ b/src/main/webapp/WEB-INF/view/allConversations.jsp
@@ -58,8 +58,10 @@
     <%
       for(Conversation conversation : conversations){
     %>
+    <%if(conversation.getPublicStatus()){%>
       <li><a href="/chat/<%= conversation.getTitle() %>">
         <%= conversation.getTitle() %></a></li>
+     <% } %>
     <%
       }
     %>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -63,11 +63,8 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
       <a href="" style="float: right">&#8635;</a></h1>
 
     <hr/>
-    
-    <form>
-  <input type="radio" name="setting" value="public" checked> Public Conversation<br>
-  <input type="radio" name="setting" value="private"> Private Conversation<br>
-</form>
+
+
 
     <div id="chat">
       <ul>
@@ -90,6 +87,10 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
         <input type="text" name="message">
         <br/>
         <button type="submit">Send</button>
+        <br/>
+        <input type="radio" name="privacy" value="public" checked> Public Conversation<br>
+  		<input type="radio" name="privacy" value="private"> Private Conversation<br>
+  		<br/>
     </form>
     <% } else { %>
       <p><a href="/login">Login</a> to send a message.</p>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -83,6 +83,7 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
     %>
       <li><strong><a href="/user/<%= author %>"><%= author %></strong></a>:<%= message.getContent() %></li>
     <%
+    	if(
       }
     %>
       </ul>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -1,12 +1,9 @@
 <%--
   Copyright 2017 Google Inc.
-
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-
      http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,10 +53,8 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
     <% } else{ %>
       <a href="/login">Login</a>
     <% } %>
-    <a href="/about.jsp">About</a>
     <a href="/activityfeed">Activity Feed</a>
     <a href = "/allConversations">All Conversations</a>
-  <a href="/adminPage">Administration</a>
   </nav>
 
   <div id="container">
@@ -83,7 +78,6 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
     %>
       <li><strong><a href="/user/<%= author %>"><%= author %></strong></a>:<%= message.getContent() %></li>
     <%
-    	if(
       }
     %>
       </ul>
@@ -105,5 +99,11 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
 
   </div>
 
+  <footer>
+    <nav>
+      <a href="/adminPage">Administration</a>
+      <a href="/about.jsp">About</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -14,6 +14,7 @@
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
+<%@ page import="codeu.model.data.User" %>
 <%
 Conversation conversation = (Conversation) request.getAttribute("conversation");
 List<Message> messages = (List<Message>) request.getAttribute("messages");

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -73,6 +73,7 @@
     else{
     %>
       <ul class="mdl-list">
+      
     <%
       for(Conversation conversation : conversations){
       if(request.getSession().getAttribute("user") != null){

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -15,6 +15,8 @@
 --%>
 <%@ page import="java.util.List" %>
 <%@ page import="codeu.model.data.Conversation" %>
+<%@ page import="codeu.model.store.basic.UserStore" %>
+<%@ page import="codeu.model.data.User" %>
 
 <!DOCTYPE html>
 <html>
@@ -58,7 +60,7 @@
       <hr/>
     <% } %>
 
-    <h1>Conversations</h1>
+    <h1>Your Conversations</h1>
 
     <%
     List<Conversation> conversations =
@@ -73,13 +75,22 @@
       <ul class="mdl-list">
     <%
       for(Conversation conversation : conversations){
-    %>
+      if(request.getSession().getAttribute("user") != null){
+      	User user = UserStore.getInstance().getUser(request.getSession().getAttribute("user").toString());	
+		if(conversation.getOwnerId() == user.getId()) { %>
       <li><a href="/chat/<%= conversation.getTitle() %>">
         <%= conversation.getTitle() %></a></li>
     <%
       }
     %>
+    
+    <%
+      }
+    %>
       </ul>
+      <%
+      }
+    %>
     <%
     }
     %>

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -85,7 +85,7 @@ public class ChatServletTest {
 
     UUID fakeConversationId = UUID.randomUUID();
     Conversation fakeConversation =
-        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now(), true);
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
         .thenReturn(fakeConversation);
 
@@ -178,7 +178,7 @@ public class ChatServletTest {
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(),true);
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
         .thenReturn(fakeConversation);
 
@@ -209,7 +209,7 @@ public class ChatServletTest {
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(),true);
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
         .thenReturn(fakeConversation);
 

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -74,7 +74,7 @@ public class ConversationServletTest {
   public void testDoGet() throws IOException, ServletException {
     List<Conversation> fakeConversationList = new ArrayList<>();
     fakeConversationList.add(
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now()));
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), true));
     Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
 
     conversationServlet.doGet(mockRequest, mockResponse);

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -28,7 +28,7 @@ public class ConversationTest {
     String title = "Test_Title";
     Instant creation = Instant.now();
 
-    Conversation conversation = new Conversation(id, owner, title, creation);
+    Conversation conversation = new Conversation(id, owner, title, creation, true);
 
     Assert.assertEquals(id, conversation.getId());
     Assert.assertEquals(owner, conversation.getOwnerId());

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -18,7 +18,7 @@ public class ConversationStoreTest {
 
   private final Conversation CONVERSATION_ONE =
       new Conversation(
-          UUID.randomUUID(), UUID.randomUUID(), "conversation_one", Instant.ofEpochMilli(1000));
+          UUID.randomUUID(), UUID.randomUUID(), "conversation_one", Instant.ofEpochMilli(1000),true);
 
   @Before
   public void setup() {
@@ -62,7 +62,7 @@ public class ConversationStoreTest {
   @Test
   public void testAddConversation() {
     Conversation inputConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), true);
 
     conversationStore.addConversation(inputConversation);
     Conversation resultConversation =

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -81,13 +81,13 @@ public class PersistentDataStoreTest {
     UUID ownerOne = UUID.fromString("10000001-2222-3333-4444-555555555555");
     String titleOne = "Test_Title";
     Instant creationOne = Instant.ofEpochMilli(1000);
-    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne);
+    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne, true);
 
     UUID idTwo = UUID.fromString("10000002-2222-3333-4444-555555555555");
     UUID ownerTwo = UUID.fromString("10000003-2222-3333-4444-555555555555");
     String titleTwo = "Test_Title_Two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
-    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo);
+    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo, true);
 
     // save
     persistentDataStore.writeThrough(inputConversationOne);

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -60,7 +60,7 @@ public class PersistentStorageAgentTest {
   @Test
   public void testWriteThroughConversation() {
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), true);
     persistentStorageAgent.writeThrough(conversation);
     Mockito.verify(mockPersistentDataStore).writeThrough(conversation);
   }


### PR DESCRIPTION
Currently, users are able to mark a conversation public or private. When a conversation is marked private, it cannot be access through the page that has all of the conversations. I also changed the  Conversation page to only display conversations in which the person is active. Right now there are a few bugs I caught but I wanted to push something. One of the bugs I'm trying to figure out is how to have the private/public radio buttons not be linked to the submit button (couldn't figure out how to get them to work otherwise). Another bug is that the conversation page only displays convos that the person created recently and not all of their convos. 
![1](https://user-images.githubusercontent.com/28582843/42342583-1d5207e0-805c-11e8-899e-459be055445d.PNG)
![2](https://user-images.githubusercontent.com/28582843/42342588-1faa8c10-805c-11e8-9814-1b1494cdca9e.PNG)
![3](https://user-images.githubusercontent.com/28582843/42342591-21508510-805c-11e8-90a0-943f7d4ab623.PNG)
![4](https://user-images.githubusercontent.com/28582843/42342609-35e26dcc-805c-11e8-8c48-aa5727e7ab57.PNG)
![5](https://user-images.githubusercontent.com/28582843/42342592-22f32198-805c-11e8-8a7f-59e9cf5da3d7.PNG)
